### PR TITLE
add matchingRate diff option + test it

### DIFF
--- a/index.spec.ts
+++ b/index.spec.ts
@@ -142,6 +142,38 @@ describe("chai-image", () => {
         }).to.throw(AssertionError)
         .with.property("message", "expected image not to match given image, but none was different");
       });
+
+    context("when matchingRate is specified", () => {
+      it("should not throw AssertionError is rate is not reach", () => {
+        expect(() => {
+          expect(
+            fs.readFileSync("fixtures/red_velvet_perfect_velvet_all_2_co_l.png"),
+          ).to.matchImage(
+            fs.readFileSync("fixtures/red_velvet_perfect_velvet_all_2_co_m_l.png"),
+            {
+              diff: {
+                matchingRate: 1 - (202176 / (720 * 600)) // Allow 202176 to fail
+              }
+            }
+          );
+        }).to.not.throw(AssertionError)
+      });
+
+      it("should throw AssertionError is rate is reach", () => {
+        expect(() => {
+          expect(
+            fs.readFileSync("fixtures/red_velvet_perfect_velvet_all_2_co_l.png"),
+          ).to.matchImage(
+            fs.readFileSync("fixtures/red_velvet_perfect_velvet_all_2_co_m_l.png"),
+            {
+              diff: {
+                matchingRate: 1 - (202174 / (720 * 600)) // Allow 202174 to fail
+              }
+            }
+          );
+        }).to.throw(AssertionError)
+      });
+    })
     });
 
     describe("for output creation", () => {

--- a/index.ts
+++ b/index.ts
@@ -20,6 +20,10 @@ export interface DiffOptions {
   aaColor?: [number, number, number];
   /* The color of differing pixels in the diff output. [255, 0, 0] by default. */
   diffColor?: [number, number, number];
+
+  // Matching amount percentage of pixel, ranges from 0 to 1.
+  // Percentage of pixels which must match to validate the test, 1 by default
+  matchingRate?: number;
 }
 
 export interface OutputOptions {
@@ -65,10 +69,13 @@ export const chaiImage: Chai.ChaiPlugin = (chai: Chai.ChaiStatic, utils: Chai.Ch
     if (actualHash !== expectedHash) {
       // if hash is different, perform imagediff
       const { width, height } = imgExpected;
+      const size = width * height;
+      const mustMatch = size * (options.diff?.matchingRate ?? 1);
+
       const imgDiff = new PNG({ width, height });
 
       const diffPixelCount = pixelmatch(imgActual.data, imgExpected.data, imgDiff.data, width, height, options.diff);
-      const passed = diffPixelCount === 0;
+      const passed = diffPixelCount <= (size - mustMatch);
 
       if (options.output) {
         saveImages(passed, imgActual, imgExpected, imgDiff, options.output);


### PR DESCRIPTION
Adding a new diff option matchingRate.
It allow the user to specify an amount of pixel (in percentage) that can differ before throwing the assertion.
This could be useful if you try to compare output of image processor where the result could differ a bit for a same input. 